### PR TITLE
Fix plural of media breaking change

### DIFF
--- a/lib/Doctrine/Inflector/Rules/English/Uninflected.php
+++ b/lib/Doctrine/Inflector/Rules/English/Uninflected.php
@@ -40,6 +40,7 @@ final class Uninflected
         yield new Pattern('people');
         yield new Pattern('trivia');
         yield new Pattern('\w+ware$');
+        yield new Pattern('media');
     }
 
     /**

--- a/tests/Doctrine/Tests/Common/Inflector/InflectorTest.php
+++ b/tests/Doctrine/Tests/Common/Inflector/InflectorTest.php
@@ -98,6 +98,7 @@ class InflectorTest extends TestCase
             array('matrix', 'matrices'),
             array('matrix_row', 'matrix_rows'),
             array('medium', 'media'),
+            array('media', 'media'),
             array('memorandum', 'memoranda'),
             array('menu', 'menus'),
             array('Menu', 'Menus'),


### PR DESCRIPTION
When using 1.3 of inflector, the plural of media was `media` (which is correct, media is already the plural of medium). When updating to 1.4 the plural became `medias`, which I believe is incorrect but also a breaking change.

1.3.1:
```
echo Inflector::pluralize('media');
// media
```

1.4.0:
```
echo Inflector::pluralize('media');
// medias
```

Related issue that was caused by this change: https://github.com/spatie/laravel-medialibrary/issues/1864

Possible related PR: https://github.com/doctrine/inflector/pull/125 